### PR TITLE
Update fp_herb_converter

### DIFF
--- a/R/fp_herb_converter.R
+++ b/R/fp_herb_converter.R
@@ -50,6 +50,8 @@
 #'                   lat = NULL,
 #'                   long = NULL,
 #'                   alt = NULL,
+#'                   add_census_notes = TRUE,
+#'                   validate_locality = TRUE,
 #'                   dir = "Results_rainfor_herb",
 #'                   filename = "rainfor_to_herb")
 #'
@@ -89,6 +91,9 @@
 #'
 #' @param alt Altitude in meters of the collection site. If \code{'NULL'},
 #' extract the altitude from geographic coordinates dataset.
+#' 
+#' @param validate_locality If \code{TRUE} (default), validates whether the 
+#' coordinates fall within the provided administrative division (country/majorarea).
 #'
 #' @param add_census_notes If \code{'TRUE'}, census notes will be included in the
 #' herbarium  sheet's notes. If \code{'FALSE'}, census notes will be omitted.
@@ -102,7 +107,6 @@
 #'
 #' @return A data frame in herbarium format with the processed data from
 #' forestplots dataset.
-#'
 #'
 #' @examples
 #' fp_herb_converter <- function(fp_file_path = NULL,
@@ -121,6 +125,7 @@
 #'                               long = NULL,
 #'                               alt = NULL,
 #'                               add_census_notes = TRUE,
+#'                               validate_locality = TRUE,
 #'                               dir = "Results_filled_herbarium_sheet",
 #'                               filename =  "forestplot_to_herbarium_sheet")
 #'
@@ -149,67 +154,70 @@ fp_herb_converter <- function(fp_file_path = NULL,
                               long = NULL,
                               alt = NULL,
                               add_census_notes = TRUE,
+                              validate_locality = TRUE,
                               dir = "Results_filled_herbarium_sheet",
                               filename =  "forestplot_to_herbarium_sheet") {
-
-
+  
+  
   # Apply defensive functions. to verify if required arguments are present
-
+  
   # dir check
   dir <- .arg_check_dir(dir)
-
+  
   # majorarea check
   majorarea <- .arg_check_majorarea(majorarea, country)
-
+  
   # minorarea check
   .arg_check_minorarea(minorarea)
-
+  
   # lat check
   lat <- .arg_check_lat(lat)
-
+  
   # long check
   long <- .arg_check_long(long)
-
+  
   # alt check
   alt <- .arg_check_alt(alt)
-
-  # check if a point falls within a given administrative division
-  .check_point_in_admin(lat = lat,
-                        long = long,
-                        majorarea = majorarea,
-                        country = country)
-
+  
+  # check if a point falls within a given administrative division (OPTIONAL)
+  if (isTRUE(validate_locality)) {
+    .check_point_in_admin(lat = lat,
+                          long = long,
+                          majorarea = majorarea,
+                          country = country)
+  }
+  
   # Creating the directory to save the file based on the current date
   # Make folder name to save search results  e.g.: 05Dec2024
   foldername <- paste0(dir, "/", format(Sys.time(), "%d%b%Y"))
-
+  
   # Create the main 'Results_filled_herbarium_sheet' folder and subfolders with
   # the date,  if they don't exist
   if (!dir.exists(dir)) dir.create(dir)
   if (!dir.exists(foldername)) dir.create(foldername)
-
+  
   # Create the file path name for the spreadsheet to be saved in .xlsx format
   fullname <- paste0(foldername, "/", filename, ".xlsx")
-
+  
   #### Load Data ####
   # Load forestplot spreadsheet (adjust file name as needed)
   fp_sheet <- suppressMessages({readxl::read_excel(fp_file_path, sheet = 1)
   })
-
+  
   # Load the empty herbarium spreadsheet (adjust file name as needed)
   herb_sheet <- readxl::read_excel(herb_file_path)
-
+  
   # Extract information for 'collector' and 'addcoll' before modifying the dataset
   if (is.null(collector) | is.null(addcoll)) {
-
+    
     team_col <- which(grepl("^Team[:]", names(fp_sheet)))
-
+    
     team_info <- strsplit(as.character(names(fp_sheet)[team_col]), ",")
-
+    
     if (is.null(collector)) {
       collector <- sapply(team_info, function(x) trimws(strsplit(x[1], ":")[[1]][2]))
     }
-
+    
     if (is.null(addcoll)) {
       addcoll <- sapply(team_info, function(x) {
         if (length(x) > 1) {
@@ -220,60 +228,60 @@ fp_herb_converter <- function(fp_file_path = NULL,
       })
     }
   }
-
+  
   # Check if alt is NULL and use the user-provided value (if available)
   if (is.null(alt)) {
     # If alt is NULL, proceed with elevation extraction logic
     # Download global elevation data at 2.5 arc-second resolution (~75m at equator)
     elev <- geodata::elevation_global(res = 2.5, path = tempdir())
-
+    
     # Create spatial points object from coordinates
     points <- data.frame(lon = long, lat = lat)
     points_sp <- terra::vect(points,
                              geom = c("lon", "lat"),
                              crs = "EPSG:4326")  # WGS84 coordinate system
-
+    
     # Extract elevation values for the points
     elev_values <- terra::extract(elev, points_sp)
-
+    
     # Get elevation values from the second column (first column is ID)
     alt <- elev_values[, 2]
-
+    
     # Convert to numeric
     alt <- as.numeric(alt)
-
+    
     # Remove the elevation data file from the disk after extraction
     unlink(elev)
   }
-
+  
   # Extract the date from the 11th column name (format: "Date: dd/mm/yy")
   date_col <- grep("^Date: \\d{2}/\\d{2}/\\d{2}$", names(fp_sheet))
   date_col <- grep("^Date: \\d{2}/\\d{2}/\\d{4}$", names(fp_sheet))
   date_info <- strsplit(names(fp_sheet)[date_col], "Date: ")[[1]][2]
-
+  
   # Split the date into day, month, and year
   date_parts <- strsplit(date_info, "/")[[1]]
   colldd <- date_parts[1]
   collmm <- date_parts[2]
   collyy <- date_parts[3]
-
+  
   # Remove the first row as it's not relevant
   colnames(fp_sheet) <- fp_sheet[1, ]
   fp_sheet <- fp_sheet[-1, ]
-
+  
   # Edit original info in the forestplot sheet
   # Filtrar apenas as linhas com alguma informação na coluna 'Collected'
   fp_sheet <- fp_sheet[!is.na(fp_sheet$Collected) & fp_sheet$Collected != "", ]
   fp_sheet$D <- as.numeric(fp_sheet$D)/10
   fp_sheet$'Census Notes' <- gsub("[.]$", "", fp_sheet$'Census Notes')
   fp_sheet$'Census Notes' <- .convert_to_lowercase(string=fp_sheet$'Census Notes')
-
+  
   # Prepare the herb_sheet DataFrame structure
   n <- length(unique(na.omit(fp_sheet$Voucher)))
   mtemp <- as.data.frame(matrix(NA, n, ncol(herb_sheet)))
   names(mtemp) <- names(herb_sheet)
   herb_sheet <- mtemp
-
+  
   if (herbarium_format == "jabot"){
     # Fill the herb_sheet columns with necessary information
     herb_sheet$family <- ifelse(grepl("(i|I)ndet", fp_sheet$Family), NA, fp_sheet$Family)
@@ -293,37 +301,37 @@ fp_herb_converter <- function(fp_file_path = NULL,
     herb_sheet$longitude <- long
     herb_sheet$altprof <- alt
     notes <- "notes"
-
+    
     # Update genus and sp1 based on 'Original determination' column
     for (i in 1:nrow(fp_sheet)) {
       # Split the 'Original determination' into components (gênero e espécie)
       determination <- strsplit(as.character(fp_sheet$`Original determination`)[i], " ")[[1]]
-
+      
       # Fill genus (first word), and replace "indet" with ""
       herb_sheet$genus[i] <- ifelse(length(determination) > 0,
                                     gsub("(i|I)ndet", NA, determination[1]), NA)
-
+      
       # Fill sp1 (second word if available), and replace "indet" with ""
       herb_sheet$sp1[i] <- ifelse(length(determination) > 1,
                                   gsub("indet", NA, determination[2]), NA)
-
+      
       # Ensure sp1 is different from genus
       herb_sheet$sp1[i] <- ifelse(is.na(herb_sheet$sp1[i]) | herb_sheet$sp1[i] == herb_sheet$genus[i],
                                   NA, herb_sheet$sp1[i])
     }
-
-
+    
+    
     # Build the final notes entry
     herb_sheet <- .build_notes(fp_sheet, herb_sheet, i, notes = notes,
                                language = language,
                                add_census_notes = add_census_notes)
-
+    
     # Saving the file in the correct directory
     message(paste0("Writing spreadsheet '", filename, ".xlsx' within '",
                    dir, "' on disk."))
-
+    
     openxlsx::write.xlsx(herb_sheet, fullname)
-
+    
     # Return spreadsheet to R environment
     return(herb_sheet)
   }
@@ -346,7 +354,7 @@ fp_herb_converter <- function(fp_file_path = NULL,
     herb_sheet$Longitude <- long
     herb_sheet$Elevation <- alt
     notes <- "DescriptionText"
-
+    
     # Update GenusName and SpeciesName based on 'Original determination' column
     for (i in 1:nrow(fp_sheet)) {
       # Split the 'Original determination' into components (gênero e espécie)
@@ -357,27 +365,27 @@ fp_herb_converter <- function(fp_file_path = NULL,
       # Fill GenusName (first word), and replace "indet" with ""
       herb_sheet$GenusName[i] <- ifelse(length(determination) > 0,
                                         gsub("(i|I)ndet", NA, determination[1]), NA)
-
+      
       # Fill SpeciesName (second word if available), and replace "indet" with ""
       herb_sheet$SpeciesName[i] <- ifelse(length(determination) > 1,
                                           gsub("indet", NA, determination[2]), NA)
-
+      
       # Ensure SpeciesName is different from GenusName
       herb_sheet$SpeciesName[i] <- ifelse(is.na(herb_sheet$SpeciesName[i]) | herb_sheet$SpeciesName[i] == herb_sheet$GenusName[i],
                                           NA, herb_sheet$SpeciesName[i])
     }
-
+    
     # Build the final notes entry
     herb_sheet <- .build_notes(fp_sheet, herb_sheet, i, notes = notes,
                                language = language,
                                add_census_notes = add_census_notes)
-
+    
     # Saving the file in the correct directory
     message(paste0("Writing spreadsheet '", filename, ".xlsx' within '",
                    dir, "' on disk."))
-
+    
     openxlsx::write.xlsx(herb_sheet, fullname)
-
+    
     # Return spreadsheet to R environment
     return(herb_sheet)
   }
@@ -401,7 +409,7 @@ fp_herb_converter <- function(fp_file_path = NULL,
     herb_sheet[[column_map$long]] <- long
     herb_sheet[[column_map$alt]] <- alt
     notes <- column_map[["notes"]]
-
+    
     # Update GenusName and SpeciesName based on 'Original determination' column
     for (i in 1:nrow(fp_sheet)) {
       # Split the 'Original determination' into components (gênero e espécie)
@@ -412,27 +420,27 @@ fp_herb_converter <- function(fp_file_path = NULL,
       # Fill GenusName (first word), and replace "indet" with ""
       herb_sheet[[column_map$genus]][i] <- ifelse(length(determination) > 0,
                                                   gsub("(i|I)ndet", NA, determination[1]), NA)
-
+      
       # Fill SpeciesName (second word if available), and replace "indet" with ""
       herb_sheet[[column_map$sp1]][i] <- ifelse(length(determination) > 1,
                                                 gsub("indet", NA, determination[2]), NA)
-
+      
       # Ensure SpeciesName is different from GenusName
       herb_sheet[[column_map$sp1]][i] <- ifelse(is.na(herb_sheet[[column_map$sp1]][i]) | herb_sheet[[column_map$sp1]][i] == herb_sheet[[column_map$genus]][i],
                                                 NA, herb_sheet[[column_map$sp1]][i])
     }
-
+    
     # Build the final notes entry
     herb_sheet <- .build_notes(fp_sheet, herb_sheet, i, notes = notes,
                                language = language,
                                add_census_notes = add_census_notes)
-
+    
     # Saving the file in the correct directory
     message(paste0("Writing spreadsheet '", filename, ".xlsx' within '",
                    dir, "' on disk."))
-
+    
     openxlsx::write.xlsx(herb_sheet, fullname)
-
+    
     # Return spreadsheet to R environment
     return(herb_sheet)
   }
@@ -456,7 +464,7 @@ fp_herb_converter <- function(fp_file_path = NULL,
     herb_sheet[[column_map$long]] <- long
     herb_sheet[[column_map$alt]] <- alt
     notes <- column_map[["notes"]]
-
+    
     # Update GenusName and SpeciesName based on 'Original determination' column
     for (i in 1:nrow(fp_sheet)) {
       # Split the 'Original determination' into components (gênero e espécie)
@@ -467,25 +475,25 @@ fp_herb_converter <- function(fp_file_path = NULL,
       # Fill GenusName (first word), and replace "indet" with ""
       herb_sheet[[column_map$genus]][i] <- ifelse(length(determination) > 0,
                                                   gsub("(i|I)ndet", NA, determination[1]), NA)
-
+      
       # Fill SpeciesName (second word if available), and replace "indet" with ""
       herb_sheet[[column_map$sp1]][i] <- ifelse(length(determination) > 1,
                                                 gsub("indet", NA, determination[2]), NA)
-
+      
       # Ensure SpeciesName is different from GenusName
       herb_sheet[[column_map$sp1]][i] <- ifelse(is.na(herb_sheet[[column_map$sp1]][i]) | herb_sheet[[column_map$sp1]][i] == herb_sheet[[column_map$genus]][i],
                                                 NA, herb_sheet[[column_map$sp1]][i])
     }
-
+    
     # Build the final notes entry
     herb_sheet <- .build_notes(fp_sheet, herb_sheet, i, notes = notes,
                                language = language,
                                add_census_notes = add_census_notes)
-
+    
     # Saving the file in the correct directory
     message(paste0("Writing spreadsheet '", filename, ".xlsx' within '",
                    dir, "' on disk."))
-
+    
     openxlsx::write.xlsx(herb_sheet, fullname)
     # Return spreadsheet to R environment
     return(herb_sheet)
@@ -638,19 +646,19 @@ fp_herb_converter <- function(fp_file_path = NULL,
 .convert_to_lowercase <- function(string) {
   for (l in 1:length(string)) {
     if (!is.na(string[l])) {
-
+      
       # Split the text by spaces to get individual words
       string_temp <- strsplit(string[l], " ")[[1]]
-
+      
       # Convert all words to lowercase
       string_temp <- tolower(string_temp)
-
+      
       # Rejoin the words into a single string
       modified_string <- paste(string_temp, collapse = " ")
-
+      
       # Replace any period (.) with a comma (,)
       modified_string <- gsub("\\.", ",", modified_string)
-
+      
       # Assign the modified string back
       string[l] <- modified_string
     } else {
@@ -658,7 +666,7 @@ fp_herb_converter <- function(fp_file_path = NULL,
       string[l] <- ""
     }
   }
-
+  
   # Return the modified string
   return(string)
 }
@@ -667,20 +675,20 @@ fp_herb_converter <- function(fp_file_path = NULL,
 .build_notes <- function(fp_sheet, herb_sheet, i, notes = notes,
                          language = "en",
                          add_census_notes = TRUE) {
-
+  
   # Loop through each row in the fp_sheet data
   for (i in 1:nrow(fp_sheet)) {
-
+    
     # Process Flag1 descriptions
     flag_letters <- strsplit(tolower(fp_sheet$Flag1[i]), split = "")[[1]]
     converted_descriptions <- .get_descriptions(language = language)$description[match(flag_letters,                                                                                   .get_descriptions(language = language)$letters)]
     description_flag <- paste(converted_descriptions, collapse = ", ")
-
+    
     # Process LI (luminosity) descriptions
     li_code <- as.character(fp_sheet$LI[i])
     description_li <- .get_luminosity(language = language)$description[match(li_code,
                                                                              .get_luminosity(language = language)$code)]
-
+    
     # Constructing the herbarium notes based on the language
     # English version
     if (language == "en") {
@@ -695,8 +703,8 @@ fp_herb_converter <- function(fp_file_path = NULL,
                                          ifelse(!is.na(fp_sheet$'New Tag No'[i]) & fp_sheet$'New Tag No'[i] != "",
                                                 paste0("Individual #", fp_sheet$'New Tag No'[i]), ""),
                                          ifelse(!is.na(fp_sheet$T1[i]) & fp_sheet$T1[i] != "",
-                                                paste0(" in the subplot ", fp_sheet$T1, ", x = ", fp_sheet$X, "m, y = ", fp_sheet$Y, "m."), ""))
-
+                                                paste0(" in the subplot ", fp_sheet$T1[1], ", x = ", fp_sheet$X[1], "m, y = ", fp_sheet$Y[1], "m."), ""))
+        
       } else {
         herb_sheet[[notes]][i] <- paste0("Tree, ",
                                          ifelse(!is.na(fp_sheet$D[i]) & fp_sheet$D[i] != "",
@@ -706,11 +714,11 @@ fp_herb_converter <- function(fp_file_path = NULL,
                                          ifelse(!is.na(fp_sheet$'New Tag No'[i]) & fp_sheet$'New Tag No'[i] != "",
                                                 paste0("Individual #", fp_sheet$'New Tag No'[i]), ""),
                                          ifelse(!is.na(fp_sheet$T1[i]) & fp_sheet$T1[i] != "",
-                                                paste0(" in the subplot ", fp_sheet$T1, ", x = ", fp_sheet$X, "m, y = ", fp_sheet$Y, "m."), ""))
+                                                paste0(" in the subplot ", fp_sheet$T1[i], ", x = ", fp_sheet$X, "m, y = ", fp_sheet$Y, "m."), ""))
       }
-
+      
     } else if (language == "pt") {
-
+      
       # Portuguese version
       if (add_census_notes) {
         herb_sheet[[notes]][i] <- paste0("Árvore, ",
@@ -723,8 +731,8 @@ fp_herb_converter <- function(fp_file_path = NULL,
                                          ifelse(!is.na(fp_sheet$'New Tag No'[i]) & fp_sheet$'New Tag No'[i] != "",
                                                 paste0("Indivíduo #", fp_sheet$'New Tag No'[i]), ""),
                                          ifelse(!is.na(fp_sheet$T1[i]) & fp_sheet$T1[i] != "",
-                                                paste0(" na subparcela ", fp_sheet$T1, ", x = ", fp_sheet$X, "m, y = ", fp_sheet$Y, "m."), ""))
-
+                                                paste0(" na subparcela ", fp_sheet$T1[i], ", x = ", fp_sheet$X, "m, y = ", fp_sheet$Y, "m."), ""))
+        
       } else {
         herb_sheet[[notes]][i] <- paste0("Árvore, ",
                                          ifelse(!is.na(fp_sheet$D[i]) & fp_sheet$D[i] != "",
@@ -734,11 +742,11 @@ fp_herb_converter <- function(fp_file_path = NULL,
                                          ifelse(!is.na(fp_sheet$'New Tag No'[i]) & fp_sheet$'New Tag No'[i] != "",
                                                 paste0("Indivíduo #", fp_sheet$'New Tag No'[i]), ""),
                                          ifelse(!is.na(fp_sheet$T1[i]) & fp_sheet$T1[i] != "",
-                                                paste0(" na subparcela ", fp_sheet$T1, ", x = ", fp_sheet$X, "m, y = ", fp_sheet$Y, "m."), ""))
+                                                paste0(" na subparcela ", fp_sheet$T1[i], ", x = ", fp_sheet$X, "m, y = ", fp_sheet$Y, "m."), ""))
       }
-
+      
     } else if (language == "es") {
-
+      
       # Spanish version
       if (add_census_notes) {
         herb_sheet[[notes]][i] <- paste0("Árbol, ",
@@ -751,8 +759,8 @@ fp_herb_converter <- function(fp_file_path = NULL,
                                          ifelse(!is.na(fp_sheet$'New Tag No'[i]) & fp_sheet$'New Tag No'[i] != "",
                                                 paste0("Individuo #", fp_sheet$'New Tag No'[i]), ""),
                                          ifelse(!is.na(fp_sheet$T1[i]) & fp_sheet$T1[i] != "",
-                                                paste0(" en la subparcelas ", fp_sheet$T1, ", x = ", fp_sheet$X, "m, y = ", fp_sheet$Y, "m."), ""))
-
+                                                paste0(" en la subparcelas ", fp_sheet$T1[i], ", x = ", fp_sheet$X, "m, y = ", fp_sheet$Y, "m."), ""))
+        
       } else {
         herb_sheet[[notes]][i] <- paste0("Árbol, ",
                                          ifelse(!is.na(fp_sheet$D[i]) & fp_sheet$D[i] != "",
@@ -762,12 +770,11 @@ fp_herb_converter <- function(fp_file_path = NULL,
                                          ifelse(!is.na(fp_sheet$'New Tag No'[i]) & fp_sheet$'New Tag No'[i] != "",
                                                 paste0("Individuo #", fp_sheet$'New Tag No'[i]), ""),
                                          ifelse(!is.na(fp_sheet$T1[i]) & fp_sheet$T1[i] != "",
-                                                paste0(" en la subparcelas ", fp_sheet$T1, ", x = ", fp_sheet$X, "m, y = ", fp_sheet$Y, "m."), ""))
+                                                paste0(" en la subparcelas ", fp_sheet$T1[i], ", x = ", fp_sheet$X, "m, y = ", fp_sheet$Y, "m."), ""))
       }
     }
-
+    
   }
-
+  
   return(herb_sheet)
 }
-


### PR DESCRIPTION
This PR introduces an optional administrative locality validation step in fp_herb_converter() by adding a new parameter, validate_locality (default TRUE), which preserves the current behavior. When validate_locality = TRUE, the function runs the existing .check_point_in_admin() verification to ensure the provided coordinates fall within the specified administrative division. In addition, it fixes a bug in the notes assembly logic (.build_notes)